### PR TITLE
Add Jupyter Notebook Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,16 @@ RUN apt-get update && apt-get install -y sudo
 RUN pip install nose sklearn scipy pandas
 RUN pip install cltk==0.1.110
 
+ARG CLTK_UID="1000"
+ARG CLTK_GID="100"
+
 # Use the following two lines to use a local checkout of cltk instead of pip:
 # ADD cltk /cltk
 # RUN python setup.py install
 COPY install_corpora.py /cltk/install_corpora.py
 WORKDIR /cltk
-RUN groupadd -g 999 -r cltk && useradd -u 999 --no-log-init -r -m -g cltk cltk && echo 'cltk  ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/cltk
-RUN mkdir /cltk_data /nltk_data /data && chown cltk:cltk /cltk_data /nltk_data /data && chown -R cltk:cltk /cltk
+RUN useradd -u $CLTK_UID --no-log-init -m -g $CLTK_GID cltk && echo 'cltk  ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/cltk
+RUN mkdir /cltk_data /nltk_data /data && chown cltk:$CLTK_GID /cltk_data /nltk_data /data && chown -R cltk:$CLTK_GID /cltk
 USER cltk
 RUN cd ~ && ln -s /cltk_data && ln -s /nltk_data && ln -s /data
 VOLUME /cltk_data /nltk_data /data

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -1,0 +1,14 @@
+FROM jupyter/minimal-notebook
+
+RUN pip install cltk==0.1.110 && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
+
+USER root
+
+RUN mkdir /cltk_data /nltk_data /data && chown $NB_USER:$NB_GID /cltk_data /nltk_data /data
+
+USER $NB_UID
+
+RUN cd ~ && ln -s /cltk_data && ln -s /nltk_data && ln -s /data
+VOLUME /cltk_data /nltk_data /data

--- a/README.md
+++ b/README.md
@@ -48,5 +48,10 @@ This container also comes with a helper script, `install_corpora.py`, which can 
 Or corpora for specific languages:
 
     docker run -ti -v cltk_data:/cltk_data cltk install_corpora.py greek latin
+
+# Jupyter Notebook
+
+The `Dockerfile.jupyter` file also defines a Jupyter Notebook container with CLTK installed. You can build it with `docker build -t cltk-jupyter -f Dockerfile.jupyter .`, and run it with e.g. (also using a mapped data volume as in the example above) `docker run -p 8888:8888 -v cltk_data:/cltk_data cltk-jupyter` (see the [Jupyter Docker Stacks Quick Start documentation](https://github.com/jupyter/docker-stacks#quick-start) for more examples)
+
 # License
 MIT. See LICENSE.txt.


### PR DESCRIPTION
Also sets UID/GID the same across Dockerfiles to allow correct permissions when sharing a Docker volume between both containers.

See: cltk/cltk#936